### PR TITLE
Feat/segment

### DIFF
--- a/src/main/java/com/behavior/sdk/trigger/log_event/dto/LogEventCreateRequest.java
+++ b/src/main/java/com/behavior/sdk/trigger/log_event/dto/LogEventCreateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -27,4 +28,8 @@ public class LogEventCreateRequest {
    @NotBlank
    @Schema(description = "이벤트 발생한 URL", example = "https://example.com")
    private String pageUrl;
+
+   @NotNull
+   @Schema(description = "Condition ID", example = "123e4567-e89b-12d3-a456-426614174000")
+   private UUID conditionId;
 }

--- a/src/main/java/com/behavior/sdk/trigger/log_event/dto/LogEventResponse.java
+++ b/src/main/java/com/behavior/sdk/trigger/log_event/dto/LogEventResponse.java
@@ -24,6 +24,9 @@ public class LogEventResponse {
    @Schema(description = "방문자 ID", example = "3f8b1c2e-4d3a-4b5e-8c7f-9a0d1e2f3a4b")
    private UUID visitorId;
 
+   @Schema(description = "Condition ID", example = "3f8b1c2e-4d3a-4b5e-8c7f-9a0d1e2f3a4b")
+   private UUID conditionId;
+
    @Schema(description = "이벤트 타입", example = "page_view")
    private EventType eventType;
 

--- a/src/main/java/com/behavior/sdk/trigger/log_event/entity/LogEvent.java
+++ b/src/main/java/com/behavior/sdk/trigger/log_event/entity/LogEvent.java
@@ -1,5 +1,6 @@
 package com.behavior.sdk.trigger.log_event.entity;
 
+import com.behavior.sdk.trigger.condition.entity.Condition;
 import com.behavior.sdk.trigger.log_event.enums.EventType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,6 +27,10 @@ public class LogEvent {
 
    @Column(name="visitor_id", nullable = false, columnDefinition = "uuid")
    private UUID visitorId;
+
+   @ManyToOne(optional = false)
+   @JoinColumn(name = "condition_id", nullable = true)
+   private Condition condition;
 
    @Enumerated(EnumType.STRING)
    @Column(name="event_type", nullable = false)

--- a/src/main/java/com/behavior/sdk/trigger/log_event/repository/LogEventRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/log_event/repository/LogEventRepository.java
@@ -24,4 +24,18 @@ public interface LogEventRepository extends JpaRepository<LogEvent, UUID> {
          @Param("visitorId") UUID visitorId);
 
    List<LogEvent> findAllByProjectId(UUID projectId);
+
+   @Query(
+         """
+               select le.visitorId
+               from LogEvent le
+               where le.condition.id = :conditionId
+               and le.pageUrl = :pageUrl
+               group by le.visitorId
+               having count(le) >= :threshold
+               """
+   )
+   List<UUID> findVisitorIdsByCondition(@Param("conditionId") UUID conditionId,
+                                        @Param("threshold") Integer threshold,
+                                        @Param("pageUrl") String pageUrl);
 }

--- a/src/main/java/com/behavior/sdk/trigger/log_event/service/LogEventServiceImpl.java
+++ b/src/main/java/com/behavior/sdk/trigger/log_event/service/LogEventServiceImpl.java
@@ -1,9 +1,10 @@
 package com.behavior.sdk.trigger.log_event.service;
 
+import com.behavior.sdk.trigger.condition.entity.Condition;
+import com.behavior.sdk.trigger.condition.repository.ConditionRepository;
 import com.behavior.sdk.trigger.log_event.dto.LogEventCreateRequest;
 import com.behavior.sdk.trigger.log_event.dto.LogEventResponse;
 import com.behavior.sdk.trigger.log_event.entity.LogEvent;
-import com.behavior.sdk.trigger.log_event.enums.EventType;
 import com.behavior.sdk.trigger.log_event.repository.LogEventRepository;
 import com.behavior.sdk.trigger.project.repository.ProjectRepository;
 import com.behavior.sdk.trigger.visitor.repository.VisitorRepository;
@@ -24,6 +25,7 @@ public class LogEventServiceImpl implements LogEventService {
    private final LogEventRepository logEventRepository;
    private final ProjectRepository projectRepository;
    private final VisitorRepository visitorRepository;
+   private final ConditionRepository conditionRepository;
 
    @Override
    public LogEventResponse createLogEvent(UUID projectId, UUID visitorId, LogEventCreateRequest request) {
@@ -36,9 +38,18 @@ public class LogEventServiceImpl implements LogEventService {
          throw new EntityNotFoundException("방문자를 찾을 수 없습니다.");
       }
 
+      Condition condition = null;
+      if (request.getConditionId() != null) {
+         condition = conditionRepository.findById(request.getConditionId())
+                 .orElseThrow(() -> new EntityNotFoundException("조건을 찾을 수 없습니다."));
+      } else {
+         throw new IllegalArgumentException("conditionId는 null일 수 없습니다.");
+      }
+
       LogEvent logEvent = LogEvent.builder()
             .projectId(projectId)
             .visitorId(visitorId)
+            .condition(condition)
             .eventType(request.getEventType())
             .occurredAt(request.getOccurredAt() != null ? request.getOccurredAt() : LocalDateTime.now())
             .pageUrl(request.getPageUrl())
@@ -87,6 +98,7 @@ public class LogEventServiceImpl implements LogEventService {
             .id(logEvent.getId())
             .projectId(logEvent.getProjectId())
             .visitorId(logEvent.getVisitorId())
+            .conditionId(logEvent.getCondition() != null ? logEvent.getCondition().getId() : null)
             .eventType(logEvent.getEventType())
             .occurredAt(logEvent.getOccurredAt())
             .createdAt(logEvent.getCreatedAt())

--- a/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentController.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentController.java
@@ -1,0 +1,72 @@
+package com.behavior.sdk.trigger.segment.controller;
+
+import com.behavior.sdk.trigger.segment.dto.SegmentCreateRequest;
+import com.behavior.sdk.trigger.segment.dto.SegmentResponse;
+import com.behavior.sdk.trigger.segment.entity.Segment;
+import com.behavior.sdk.trigger.segment.entity.SegmentVisitor;
+import com.behavior.sdk.trigger.segment.service.SegmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/segments")
+@RequiredArgsConstructor
+@Tag(name = "Segment", description = "세그먼트 관리 API")
+public class SegmentController {
+
+    private final SegmentService segmentService;
+
+    @PostMapping
+    @Operation(summary = "세그먼트 생성", description = "세그먼트를 생성합니다.")
+    @ApiResponse(responseCode = "201", description = "세그먼트 생성 성공")
+    public ResponseEntity<SegmentResponse> createSegment(@RequestBody SegmentCreateRequest createRequest) {
+
+        Segment segment = segmentService.createSegment(createRequest);
+
+        List<UUID> visitorIds = segment.getSegmentVisitors().stream()
+                .map(SegmentVisitor::getVisitorId)
+                .collect(Collectors.toList());
+
+        SegmentResponse segmentResponse = new SegmentResponse(
+                segment.getId(),
+                segment.getProjectId(),
+                segment.getConditionId(),
+                visitorIds
+        );
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(segmentResponse);
+    }
+
+    @GetMapping
+    @Operation(summary = "프로젝트별 모든 세그먼트 조회", description = "프로젝트 ID로 모든 세그먼트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "세그먼트 목록 조회 성공")
+    public ResponseEntity<List<SegmentResponse>> listResponseEntity(@RequestParam("projectId") UUID projectId) {
+        List<SegmentResponse> segments = segmentService.listSegments(projectId);
+        return ResponseEntity.ok(segments);
+    }
+
+    @GetMapping("/{segmentId}")
+    @Operation(summary = "단일 세그먼트 조회", description = "단일 세그먼트를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "세그먼트 조회 성공")
+    public ResponseEntity<SegmentResponse> getSegment(@PathVariable UUID segmentId) {
+        SegmentResponse segment = segmentService.getSegment(segmentId);
+        return ResponseEntity.ok(segment);
+    }
+
+    @DeleteMapping("/{segmentId}")
+    @Operation(summary = "세그먼트를 soft delete 합니다.", description = "세그먼트를 soft delete 합니다.")
+    @ApiResponse(responseCode = "204", description = "세그먼트 삭제 성공")
+    public ResponseEntity<Void> deleteSegment(@PathVariable UUID segmentId) {
+        segmentService.deleteSegment(segmentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentController.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentController.java
@@ -40,7 +40,8 @@ public class SegmentController {
                 segment.getId(),
                 segment.getProjectId(),
                 segment.getConditionId(),
-                visitorIds
+                visitorIds,
+                segment.getDeletedAt()
         );
 
         return ResponseEntity.status(HttpStatus.CREATED).body(segmentResponse);

--- a/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentEmailController.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/controller/SegmentEmailController.java
@@ -1,0 +1,29 @@
+package com.behavior.sdk.trigger.segment.controller;
+
+import com.behavior.sdk.trigger.segment.dto.EmailBatchResponse;
+import com.behavior.sdk.trigger.segment.dto.SegmentEmailSendRequest;
+import com.behavior.sdk.trigger.segment.service.SegmentEmailService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/segments")
+@RequiredArgsConstructor
+public class SegmentEmailController {
+
+    private final SegmentEmailService segmentEmailService;
+
+    @PostMapping("/{segmentId}/send-email")
+    public ResponseEntity<EmailBatchResponse> sendEmailToSegment(
+            @PathVariable UUID segmentId,
+            @RequestBody @Valid SegmentEmailSendRequest emailSendRequest) {
+        EmailBatchResponse emailBatchResponse = segmentEmailService
+                .sendEmailBatch(segmentId, emailSendRequest.getTemplateId());
+
+        return ResponseEntity.ok(emailBatchResponse);
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/dto/EmailBatchResponse.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/dto/EmailBatchResponse.java
@@ -1,0 +1,22 @@
+package com.behavior.sdk.trigger.segment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter @Setter @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "EmailBatchResponse", description = "이메일 배치 응답 payload")
+public class EmailBatchResponse {
+
+    @Schema(description = "이메일 배치 ID", example = "3f8b1c2e-4d3a-4b5e-8c7f-9a0d1e2f3a4b")
+    private UUID batchId;
+
+    @Schema(description = "보낸 이메일 수", example = "100")
+    private int sentCount;
+
+    @Schema(description = "실패한 이메일 수", example = "5")
+    private int failedCount;
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentCreateRequest.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentCreateRequest.java
@@ -1,0 +1,18 @@
+package com.behavior.sdk.trigger.segment.dto;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Data
+@Getter
+@Setter
+@Builder
+public class SegmentCreateRequest {
+
+    private UUID projectId;
+    private UUID conditionId;
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentEmailSendRequest.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentEmailSendRequest.java
@@ -1,0 +1,19 @@
+package com.behavior.sdk.trigger.segment.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.UUID;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "이메일 전송 요청 payload")
+public class SegmentEmailSendRequest {
+
+    @NotNull
+    @Schema(description = "템플릿 ID", example = "3f8b1c2e-4d3a-4b5e-8c7f-9a0d1e2f3a4b")
+    private UUID templateId;
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentResponse.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentResponse.java
@@ -3,6 +3,7 @@ package com.behavior.sdk.trigger.segment.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,4 +15,5 @@ public class SegmentResponse {
     private UUID projectId;
     private UUID conditionId;
     private List<UUID> visitorIds;
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentResponse.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/dto/SegmentResponse.java
@@ -1,0 +1,17 @@
+package com.behavior.sdk.trigger.segment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+public class SegmentResponse {
+
+    private UUID id;
+    private UUID projectId;
+    private UUID conditionId;
+    private List<UUID> visitorIds;
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/EmailBatch.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/EmailBatch.java
@@ -1,0 +1,44 @@
+package com.behavior.sdk.trigger.segment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Setter @Getter @Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "email_batch")
+public class EmailBatch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "segment_id", nullable = false)
+    private UUID segmentId;
+
+    @Column(name = "sent_count", nullable = false)
+    private int sentCount;
+
+    @Column(name = "failed_count", nullable = false)
+    private int failedCount;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -32,6 +35,9 @@ public class Segment {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @OneToMany(mappedBy = "segment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<SegmentVisitor> segmentVisitors = new HashSet<>();
+
     @PrePersist
     public void onCreated() {
         this.createdAt = LocalDateTime.now();
@@ -39,5 +45,12 @@ public class Segment {
 
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public void addVisitorsByIds(List<UUID> visitorIds) {
+        visitorIds.forEach(visitorId -> {
+            SegmentVisitor sv = new SegmentVisitor(this, visitorId);
+            this.segmentVisitors.add(sv);
+        });
     }
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
@@ -35,6 +35,7 @@ public class Segment {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Builder.Default
     @OneToMany(mappedBy = "segment", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<SegmentVisitor> segmentVisitors = new HashSet<>();
 

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/Segment.java
@@ -1,0 +1,43 @@
+package com.behavior.sdk.trigger.segment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "segment")
+public class Segment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "project_id", nullable = false, columnDefinition = "uuid")
+    private UUID projectId;
+
+    @Column(name = "condition_id", nullable = false, columnDefinition = "uuid")
+    private UUID conditionId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void onCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
@@ -1,0 +1,42 @@
+package com.behavior.sdk.trigger.segment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "segment_visitors")
+public class SegmentVisitor {
+
+    @EmbeddedId
+    private SegmentVisitorKey id;
+
+    @Embeddable
+    public static class SegmentVisitorKey implements Serializable {
+        @Column(name = "segment_id", nullable = false)
+        private Long segmentId;
+
+        @Column(name = "visitor_id", nullable = false)
+        private Long visitorId;
+
+        // equals() and hashCode() methods
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof SegmentVisitorKey)) return false;
+            SegmentVisitorKey that = (SegmentVisitorKey) o;
+            return segmentId.equals(that.segmentId) && visitorId.equals(that.visitorId);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * segmentId.hashCode() + visitorId.hashCode();
+        }
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
@@ -1,7 +1,6 @@
 package com.behavior.sdk.trigger.segment.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,24 +10,26 @@ import java.util.UUID;
 @Entity
 @Getter
 @Setter
-@Builder
 @NoArgsConstructor
-@IdClass(SegmentVisitorKey.class)
 @Table(name = "segment_visitors")
 public class SegmentVisitor {
 
-    @Id
+    @EmbeddedId
+    private SegmentVisitorKey id;
+
+    @MapsId("segmentId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "segment_id", nullable = false, columnDefinition = "uuid")
+    @JoinColumn(name = "segment_id", nullable = false)
     private Segment segment;
 
-    @Id
-    @Column(name = "visitor_id", nullable = false, columnDefinition = "uuid")
+//    @MapsId("visitorId")
+    @Column(name = "visitor_id", nullable = false, insertable = false, updatable = false)
     private UUID visitorId;
 
 
     public SegmentVisitor(Segment segment, UUID visitorId) {
         this.segment = segment;
         this.visitorId = visitorId;
+        this.id = new SegmentVisitorKey(segment.getId(), visitorId);
     }
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
@@ -1,42 +1,34 @@
 package com.behavior.sdk.trigger.segment.entity;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-import java.io.Serializable;
+import java.util.UUID;
 
 @Entity
 @Getter
 @Setter
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
+@IdClass(SegmentVisitorKey.class)
 @Table(name = "segment_visitors")
 public class SegmentVisitor {
 
-    @EmbeddedId
-    private SegmentVisitorKey id;
+    @Id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "segment_id", nullable = false, columnDefinition = "uuid")
+    private Segment segment;
 
-    @Embeddable
-    public static class SegmentVisitorKey implements Serializable {
-        @Column(name = "segment_id", nullable = false)
-        private Long segmentId;
+    @Id
+    @Column(name = "visitor_id", nullable = false, columnDefinition = "uuid")
+    private UUID visitorId;
 
-        @Column(name = "visitor_id", nullable = false)
-        private Long visitorId;
 
-        // equals() and hashCode() methods
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof SegmentVisitorKey)) return false;
-            SegmentVisitorKey that = (SegmentVisitorKey) o;
-            return segmentId.equals(that.segmentId) && visitorId.equals(that.visitorId);
-        }
-
-        @Override
-        public int hashCode() {
-            return 31 * segmentId.hashCode() + visitorId.hashCode();
-        }
+    public SegmentVisitor(Segment segment, UUID visitorId) {
+        this.segment = segment;
+        this.visitorId = visitorId;
     }
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitor.java
@@ -1,6 +1,8 @@
 package com.behavior.sdk.trigger.segment.entity;
 
+import com.behavior.sdk.trigger.visitor.entity.Visitor;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,6 +13,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "segment_visitors")
 public class SegmentVisitor {
 

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitorKey.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitorKey.java
@@ -1,0 +1,37 @@
+package com.behavior.sdk.trigger.segment.entity;
+
+import jakarta.persistence.Column;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+public class SegmentVisitorKey implements Serializable {
+    @Column(name = "segment_id", nullable = false)
+    private UUID segmentId;
+
+    @Column(name = "visitor_id", nullable = false)
+    private UUID visitorId;
+
+    public SegmentVisitorKey() {
+    }
+
+    public SegmentVisitorKey(UUID segmentId, UUID visitorId) {
+        this.segmentId = segmentId;
+        this.visitorId = visitorId;
+    }
+
+    // equals() and hashCode() methods
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SegmentVisitorKey)) return false;
+        SegmentVisitorKey that = (SegmentVisitorKey) o;
+        return Objects.equals(segmentId, that.segmentId) && Objects.equals(visitorId, that.visitorId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(segmentId, visitorId);
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitorKey.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/entity/SegmentVisitorKey.java
@@ -1,11 +1,19 @@
 package com.behavior.sdk.trigger.segment.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.UUID;
 
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class SegmentVisitorKey implements Serializable {
     @Column(name = "segment_id", nullable = false)
     private UUID segmentId;
@@ -13,15 +21,7 @@ public class SegmentVisitorKey implements Serializable {
     @Column(name = "visitor_id", nullable = false)
     private UUID visitorId;
 
-    public SegmentVisitorKey() {
-    }
-
-    public SegmentVisitorKey(UUID segmentId, UUID visitorId) {
-        this.segmentId = segmentId;
-        this.visitorId = visitorId;
-    }
-
-    // equals() and hashCode() methods
+/*    // equals() and hashCode() methods
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -33,5 +33,5 @@ public class SegmentVisitorKey implements Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(segmentId, visitorId);
-    }
+    }*/
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/EmailBatchRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/EmailBatchRepository.java
@@ -1,0 +1,9 @@
+package com.behavior.sdk.trigger.segment.repository;
+
+import com.behavior.sdk.trigger.segment.entity.EmailBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface EmailBatchRepository extends JpaRepository<EmailBatch, UUID> {
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentRepository.java
@@ -1,0 +1,11 @@
+package com.behavior.sdk.trigger.segment.repository;
+
+import com.behavior.sdk.trigger.segment.entity.Segment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SegmentRepository extends JpaRepository<Segment, UUID> {
+    List<Segment> findByProjectIdAndDeletedAtIsNull(UUID projectId);
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentRepository.java
@@ -2,10 +2,15 @@ package com.behavior.sdk.trigger.segment.repository;
 
 import com.behavior.sdk.trigger.segment.entity.Segment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface SegmentRepository extends JpaRepository<Segment, UUID> {
     List<Segment> findByProjectIdAndDeletedAtIsNull(UUID projectId);
+
+    @Query("select v.visitorId from SegmentVisitor v where v.segment.id = :segmentId")
+    List<UUID> findVisitorIdsBySegmentId(@Param("segmentId") UUID segmentId);
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
@@ -3,10 +3,15 @@ package com.behavior.sdk.trigger.segment.repository;
 import com.behavior.sdk.trigger.segment.entity.SegmentVisitor;
 import com.behavior.sdk.trigger.segment.entity.SegmentVisitorKey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface SegmentVisitorRepository extends JpaRepository<SegmentVisitor, SegmentVisitorKey> {
     List<SegmentVisitor> findByIdSegmentId(UUID segmentId);
+
+    @Query("select sv.segmentVisitorKey.visitorId from SegmentVisitor sv where sv.segmentVisitorKey.segmentId = :segmentId")
+    List<UUID> findVisitorIdsBySegmentId(@Param("segmentId") UUID segmentId);
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
@@ -1,11 +1,12 @@
 package com.behavior.sdk.trigger.segment.repository;
 
 import com.behavior.sdk.trigger.segment.entity.SegmentVisitor;
+import com.behavior.sdk.trigger.segment.entity.SegmentVisitorKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface SegmentVisitorRepository extends JpaRepository<SegmentVisitor, SegmentVisitor.SegmentVisitorKey> {
+public interface SegmentVisitorRepository extends JpaRepository<SegmentVisitor, SegmentVisitorKey> {
     List<SegmentVisitor> findByIdSegmentId(UUID segmentId);
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
@@ -1,0 +1,11 @@
+package com.behavior.sdk.trigger.segment.repository;
+
+import com.behavior.sdk.trigger.segment.entity.SegmentVisitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SegmentVisitorRepository extends JpaRepository<SegmentVisitor, SegmentVisitor.SegmentVisitorKey> {
+    List<SegmentVisitor> findByIdSegmentId(UUID segmentId);
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/repository/SegmentVisitorRepository.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 public interface SegmentVisitorRepository extends JpaRepository<SegmentVisitor, SegmentVisitorKey> {
     List<SegmentVisitor> findByIdSegmentId(UUID segmentId);
 
-    @Query("select sv.segmentVisitorKey.visitorId from SegmentVisitor sv where sv.segmentVisitorKey.segmentId = :segmentId")
+    @Query("select sv.id.visitorId from SegmentVisitor sv where sv.id.segmentId = :segmentId")
     List<UUID> findVisitorIdsBySegmentId(@Param("segmentId") UUID segmentId);
 }

--- a/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentEmailService.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentEmailService.java
@@ -1,0 +1,9 @@
+package com.behavior.sdk.trigger.segment.service;
+
+import com.behavior.sdk.trigger.segment.dto.EmailBatchResponse;
+
+import java.util.UUID;
+
+public interface SegmentEmailService {
+    EmailBatchResponse sendEmailBatch(UUID segmentId, UUID templateId);
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentEmailServiceImpl.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentEmailServiceImpl.java
@@ -1,0 +1,64 @@
+package com.behavior.sdk.trigger.segment.service;
+
+import com.behavior.sdk.trigger.email.dto.EmailSendRequest;
+import com.behavior.sdk.trigger.email.service.EmailService;
+import com.behavior.sdk.trigger.segment.dto.EmailBatchResponse;
+import com.behavior.sdk.trigger.segment.entity.EmailBatch;
+import com.behavior.sdk.trigger.segment.repository.EmailBatchRepository;
+import com.behavior.sdk.trigger.segment.repository.SegmentVisitorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SegmentEmailServiceImpl implements SegmentEmailService{
+
+    private final SegmentVisitorRepository segmentVisitorRepository;
+    private final EmailService emailService;
+    private final EmailBatchRepository emailBatchRepository;
+
+    @Override
+    public EmailBatchResponse sendEmailBatch(UUID segmentId, UUID templateId) {
+
+        List<UUID> visitorIds = segmentVisitorRepository.findVisitorIdsBySegmentId(segmentId);
+
+        int sentCount = 0;
+        int failedCount = 0;
+
+        for (UUID visitorId : visitorIds) {
+            try {
+                emailService.sendEmail(
+                        EmailSendRequest.builder()
+                                .visitorId(visitorId)
+                                .templateId(templateId)
+                                .build()
+                );
+                sentCount++;
+            } catch (Exception e) {
+                failedCount++;
+            }
+        }
+
+        EmailBatch emailBatch = EmailBatch.builder()
+                .segmentId(segmentId)
+                .sentCount(sentCount)
+                .failedCount(failedCount)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        emailBatchRepository.save(emailBatch);
+
+        return EmailBatchResponse.builder()
+                .batchId(emailBatch.getId())
+                .sentCount(sentCount)
+                .failedCount(failedCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentService.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentService.java
@@ -1,0 +1,19 @@
+package com.behavior.sdk.trigger.segment.service;
+
+import com.behavior.sdk.trigger.segment.dto.SegmentCreateRequest;
+import com.behavior.sdk.trigger.segment.dto.SegmentResponse;
+import com.behavior.sdk.trigger.segment.entity.Segment;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface SegmentService {
+
+    Segment createSegment(SegmentCreateRequest request);
+
+    List<SegmentResponse> listSegments(UUID projectId);
+
+    SegmentResponse getSegment(UUID segmentId);
+
+    void deleteSegment(UUID segmentId);
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentServiceImpl.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentServiceImpl.java
@@ -1,0 +1,91 @@
+package com.behavior.sdk.trigger.segment.service;
+
+import com.behavior.sdk.trigger.condition.entity.Condition;
+import com.behavior.sdk.trigger.condition.repository.ConditionRepository;
+import com.behavior.sdk.trigger.log_event.repository.LogEventRepository;
+import com.behavior.sdk.trigger.segment.dto.SegmentCreateRequest;
+import com.behavior.sdk.trigger.segment.dto.SegmentResponse;
+import com.behavior.sdk.trigger.segment.entity.Segment;
+import com.behavior.sdk.trigger.segment.repository.SegmentRepository;
+import com.behavior.sdk.trigger.segment.repository.SegmentVisitorRepository;
+import com.behavior.sdk.trigger.visitor.repository.VisitorRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SegmentServiceImpl implements SegmentService{
+
+    private final SegmentRepository segmentRepository;
+    private final SegmentVisitorRepository segmentVisitorRepository;
+    private final LogEventRepository logEventRepository;
+    private final VisitorRepository visitorRepository;
+    private final ConditionRepository conditionRepository;
+
+    @Override
+    public Segment createSegment(SegmentCreateRequest request) {
+
+        Condition condition = conditionRepository.findById(request.getConditionId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 조건입니다."));
+
+        Integer threshold = condition.getThreshold();
+        String pageUrl = condition.getPageUrl();
+
+        List<UUID> visitorIds = logEventRepository.findVisitorIdsByCondition(condition.getId(), threshold, pageUrl);
+
+        Segment segment = new Segment();
+        segment.setProjectId(request.getProjectId());
+        segment.setConditionId(request.getConditionId());
+        segment.addVisitorsByIds(visitorIds);
+
+        return segmentRepository.save(segment);
+    }
+
+    @Override
+    public List<SegmentResponse> listSegments(UUID projectId) {
+        List<Segment> segments = segmentRepository.findByProjectIdAndDeletedAtIsNull(projectId);
+        return segments.stream()
+                .map(s -> {
+                   List<UUID> visitorIds = s.getSegmentVisitors().stream()
+                           .map(segmentVisitor -> segmentVisitor.getVisitorId())
+                           .toList();
+                   return new SegmentResponse(
+                           s.getId(),
+                           s.getProjectId(),
+                           s.getConditionId(),
+                           visitorIds
+                   );
+                })
+                .toList();
+    }
+
+    @Override
+    public SegmentResponse getSegment(UUID segmentId) {
+        Segment segment = segmentRepository.findById(segmentId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 세그먼트입니다."));
+        List<UUID> visitorIds = segment.getSegmentVisitors().stream()
+                .map(segmentVisitor -> segmentVisitor.getVisitorId())
+                .toList();
+        return new SegmentResponse(
+                segment.getId(),
+                segment.getProjectId(),
+                segment.getConditionId(),
+                visitorIds
+        );
+    }
+
+    @Override
+    public void deleteSegment(UUID segmentId) {
+        Segment segment = segmentRepository.findById(segmentId)
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 세그먼트입니다."));
+        segment.softDelete();
+        segmentRepository.save(segment);
+    }
+}

--- a/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentServiceImpl.java
+++ b/src/main/java/com/behavior/sdk/trigger/segment/service/SegmentServiceImpl.java
@@ -14,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -45,6 +44,7 @@ public class SegmentServiceImpl implements SegmentService{
         segment.setConditionId(request.getConditionId());
         segment.addVisitorsByIds(visitorIds);
 
+
         return segmentRepository.save(segment);
     }
 
@@ -60,7 +60,8 @@ public class SegmentServiceImpl implements SegmentService{
                            s.getId(),
                            s.getProjectId(),
                            s.getConditionId(),
-                           visitorIds
+                           visitorIds,
+                           s.getDeletedAt()
                    );
                 })
                 .toList();
@@ -77,7 +78,8 @@ public class SegmentServiceImpl implements SegmentService{
                 segment.getId(),
                 segment.getProjectId(),
                 segment.getConditionId(),
-                visitorIds
+                visitorIds,
+                segment.getDeletedAt()
         );
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,15 @@
 spring:
+  mail:
+    host: smtp.your-mail-server.com
+    port: 587
+    username: localhost
+    password: localhost
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
   datasource:
     url: ${SPRING_DATASOURCE_URL}
     username: ${SPRING_DATASOURCE_USERNAME}

--- a/src/test/java/com/behavior/sdk/trigger/integration/epic2/SegmentIntegrationTests.java
+++ b/src/test/java/com/behavior/sdk/trigger/integration/epic2/SegmentIntegrationTests.java
@@ -1,0 +1,144 @@
+package com.behavior.sdk.trigger.integration.epic2;
+
+import com.behavior.sdk.trigger.segment.dto.SegmentCreateRequest;
+import com.behavior.sdk.trigger.segment.entity.Segment;
+import com.behavior.sdk.trigger.segment.repository.SegmentRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class SegmentIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper om;
+    @Autowired
+    private SegmentRepository segmentRepository;
+
+    private UUID projectId;
+    private UUID conditionId;
+    private UUID segmentId;
+
+    @BeforeAll
+    void setup() throws Exception {
+
+        String projectJson = mockMvc.perform(post("/api/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"Segment Test Project\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        projectId = UUID.fromString(om.readTree(projectJson).get("id").asText());
+
+        Map<String, Object> condition = Map.of(
+                "projectId", projectId.toString(),
+                "eventType", "page_view",
+                "operator", "GREATER_THAN",
+                "threshold", 0,
+                "pageUrl", "https://example.com"
+        );
+
+        String conditionJson = mockMvc.perform(post("/api/conditions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(condition)))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        conditionId = UUID.fromString(om.readTree(conditionJson).get("id").asText());
+
+        String visitorJson = mockMvc.perform(post("/api/visitors")
+                .param("projectId", projectId.toString()))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+        UUID visitorId = UUID.fromString(om.readTree(visitorJson).get("id").asText());
+
+        mockMvc.perform(post("/api/logs")
+                .param("projectId", projectId.toString())
+                .param("visitorId", visitorId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+            {
+              "eventType": "page_view",
+              "occurredAt": "2025-05-20T10:00:00",
+              "conditionId": "%s",
+              "pageUrl": "https://example.com"
+            }
+            """.formatted(conditionId)))
+        .andExpect(status().isCreated());
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("Segment 생성")
+    void t1_createSegment() throws Exception {
+        SegmentCreateRequest segmentRequest = SegmentCreateRequest.builder()
+                .projectId(projectId)
+                .conditionId(conditionId)
+                .build();
+
+        String segmentResponse = mockMvc.perform(post("/api/segments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(om.writeValueAsString(segmentRequest)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.visitorIds", hasSize(1)))
+                .andReturn().getResponse().getContentAsString();
+
+        segmentId = UUID.fromString(om.readTree(segmentResponse).get("id").asText());
+
+        Segment segment = segmentRepository.findById(segmentId).orElseThrow();
+        assertThat(segment.getConditionId()).isEqualTo(conditionId);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("Segment 목록 조회")
+    void t2_listSegments() throws Exception {
+        mockMvc.perform(get("/api/segments")
+                .param("projectId", projectId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("세그먼트 단건 조회")
+    void t3_getSegment() throws Exception {
+        mockMvc.perform(get("/api/segments/{id}", segmentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(segmentId.toString()))
+                .andExpect(jsonPath("$.visitorIds", hasSize(1)));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("세그먼트 삭제(soft)")
+    void t4_deleteSegment() throws Exception {
+        mockMvc.perform(delete("/api/segments/{id}", segmentId))
+                .andExpect(status().isNoContent());
+
+        // 삭제 후에도 GET 하면 404 또는 visitorIds 빈 배열이 나오도록 설계에 따라 검증
+        mockMvc.perform(get("/api/segments/{id}", segmentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.deletedAt").exists());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -12,3 +12,7 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+        logging:
+          level:
+            org:
+              hibernate=DEBUG:


### PR DESCRIPTION
Segment 도메인 구현
Segment 관리 API 구현
POST / GET(단일, list) / DELETE(soft delete)
[버그수정] 로그이벤트 생성 시 필수 필드 누락으로 인한 예외 처리
- Segment 엔티티에 deletedAt(LocalDateTime) 필드 추가
- softDelete() 메서드 구현으로 삭제 시점 기록
- SegmentResponse DTO에 deletedAt 필드 포함
- SegmentServiceImpl 및 SegmentController에서 soft delete 처리 반영
- Integration 테스트에서 삭제 후 deletedAt 검증
- SegmentVisitor 관련 @IdClass → @EmbeddedId 구조로 마이그레이션
- [test: Segment 통합 테스트 추가 (생성, 조회, 삭제)]
[add list by segmentid repository]
feat: SendEmail to Segment Batch api
test: impl sendSegmentEmailBatch
fix: findVisitorIdsBySegmentId repository query