### PR TITLE
Feat/exception

### DIFF
--- a/src/main/java/com/behavior/sdk/trigger/common/security/JwtUtils.java
+++ b/src/main/java/com/behavior/sdk/trigger/common/security/JwtUtils.java
@@ -1,7 +1,11 @@
 package com.behavior.sdk.trigger.common.security;
 
+import com.behavior.sdk.trigger.common.exception.ErrorSpec;
+import com.behavior.sdk.trigger.common.exception.FieldErrorDetail;
+import com.behavior.sdk.trigger.common.exception.ServiceException;
 import com.behavior.sdk.trigger.user.entity.User;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -12,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import java.security.Key;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -30,6 +35,29 @@ public class JwtUtils {
         this.key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
+    // 공통 Claims Parser
+    private Claims parseClaimsOrThrow(String token) {
+        try {
+            return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new ServiceException(
+                ErrorSpec.AUTH_EXPIRED_TOKEN, // 1005, 401
+                "만료된 토큰입니다.",
+                List.of(new FieldErrorDetail("token", "expired", null))
+            );
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new ServiceException(
+                ErrorSpec.AUTH_INVALID_TOKEN, // 1004, 401
+                "유효하지 않은 토큰입니다.",
+                List.of(new FieldErrorDetail("token", "invalid", token))
+            );
+        }
+    }
+
     public String generateToken(User user) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + EXPIRATION_MS);
@@ -44,23 +72,19 @@ public class JwtUtils {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder()
-                    .setSigningKey(key)
-                    .build()
-                    .parseClaimsJws(token);
+            parseClaimsOrThrow(token);
             return true;
-        } catch (JwtException | IllegalArgumentException e) {
+        } catch (ServiceException ignore) {
             return false;
         }
     }
 
     public UUID getUserIdFromToken(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-
+        Claims claims = parseClaimsOrThrow(token);
         return UUID.fromString(claims.getSubject());
+    }
+
+    public void validateTokenOrThrow(String token) {
+        parseClaimsOrThrow(token);
     }
 }


### PR DESCRIPTION
refactor: refactor exceptions in JwtUtils
refactor: refactor Interceptor exceptions
refactor: refactor excepctions in JwtFilter
->1. Authorization 헤더가 없거나 Bearer가 아니면 그대로 통과 (익명 허용)
    2. 헤더가 있는데 토큰이 유효하지 않거나 만료 시 ServiceException 던져서 GlobalHandler가 응답
    3. 토큰은 유효한데 해당 유저가 없을 시 -> 사용자 존재를 노출하지 않도록 401 통일